### PR TITLE
ci(eidetic-works-nucleus-mcp): add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@9c187f00d6706cb0c27aef4eb58f1a8869e9d6db
+        with:
+          mode: validate
+          skill-dir: .
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
This adds a lightweight validation workflow that runs the HOL skill validator against the repository root, checking schema and trust signals without requiring any secrets.

The workflow stays validate-only — it doesn't touch runtime code, release flows, or publish credentials, so it can be removed without risk.

- Runs on push to main and on PRs
- Validates skill-metadata.json against schema and checks trust signals
- Outputs results as job summary

This PR adds one workflow file to the repository root that runs the HOL skill validator in validate mode. It checks schema and trust signals only, leaving runtime code, release flow, and publish credentials untouched. The change is reversible by simply deleting the workflow file.

Happy to adjust the branch or fold this into an existing workflow if you prefer a different path.