### PR TITLE
Add SafeSkill security badge (30/100 — Blocked)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-brightgreen)](https://modelcontextprotocol.io)
 [![NPM](https://img.shields.io/badge/npm-nucleus--mcp-red)](https://www.npmjs.com/package/nucleus-mcp)
 [![nucleus-mcp MCP server](https://glama.ai/mcp/servers/eidetic-works/nucleus-mcp/badges/score.svg)](https://glama.ai/mcp/servers/eidetic-works/nucleus-mcp)
+[![SafeSkill 30/100](https://img.shields.io/badge/SafeSkill-30%2F100_Blocked-red)](https://safeskill.dev/scan/eidetic-works-nucleus-mcp)
 
 AI agents hallucinate, break code, and repeat mistakes. Nucleus catches this. Every AI output is verified, every correction is recorded, and every mistake trains the system to not repeat it. Locally, on your machine.
 


### PR DESCRIPTION
## 🔴 SafeSkill Security Scan Results

| Metric | Value |
|:-------|:------|
| **Overall Score** | **30/100** (Blocked) |
| Code Score | 95/100 |
| Content Score | 60/100 |
| Findings | 15 findings detected (12 critical) |
| Taint Flows | 0 |
| Files Scanned | 1 |
| Scan Duration | 0.3s |

### Top Findings

- 🔴 **critical**: Imports child_process module (`npm-wrapper/index.js:3`)
- 🔴 **critical**: Spawns child process (`npm-wrapper/index.js:14`)
- 🔴 **critical**: Spawns child process (`npm-wrapper/index.js:23`)
- 🔴 **critical**: Spawns child process (`npm-wrapper/index.js:33`)
- 🔴 **critical**: Spawns child process (`npm-wrapper/index.js:65`)

[View full report on SafeSkill](https://safeskill.dev/scan/eidetic-works-nucleus-mcp)

---

### About SafeSkill

[SafeSkill](https://safeskill.dev) is a **free, open-source** security scanner for AI tools, MCP servers, and Claude Code skills. We scan for code exploits, prompt injection, and data exfiltration risks.

**False positive?** We take accuracy seriously. If any finding above is incorrect, please [open an issue](https://github.com/OyadotAI/safeskill/issues/new?title=False+positive+in+eidetic-works%2Fnucleus-mcp&labels=false-positive) and we will fix it immediately.

- [GitHub](https://github.com/OyadotAI/safeskill) | [Website](https://safeskill.dev) | [Docs](https://safeskill.dev/docs)
- Built by [Oya.ai](https://oya.ai) -- AI Employees Builder
