### PR TITLE
docs(security): document npm-wrapper child_process bounded-subprocess pattern

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -149,6 +149,31 @@ Engrams may contain sensitive information. Users should:
 - Use external secret managers
 - Encrypt sensitive engram values
 
+### npm-wrapper subprocess invocations
+
+`npm-wrapper/index.js` is the npx entrypoint that bridges npm distribution to
+the Python package. It uses `child_process` because that is the only way to
+launch a separate process from Node — equivalent to how an npm package with
+native dependencies invokes `node-gyp` at install time. Static security
+scanners (e.g. SafeSkill) flag every `child_process` call site as critical
+without flow analysis; the table below is the per-call rationale.
+
+| Line | Call | Bounded by |
+|---|---|---|
+| `index.js:14` | `execSync('python3 --version', { stdio: 'ignore' })` | Hardcoded literal command. No user-input concatenation. `stdio: 'ignore'` discards output. |
+| `index.js:23` | `execSync('python3 -m mcp_server_nucleus --help', { stdio: 'ignore' })` | Hardcoded literal command. No user-input concatenation. `stdio: 'ignore'` discards output. |
+| `index.js:33` | `execSync('python3 -m pip install nucleus-mcp', { stdio: 'inherit' })` | Hardcoded literal command + hardcoded package name. No user-input concatenation. `stdio: 'inherit'` only streams pip's own output to the user terminal. By-design behavior of an npm wrapper over a Python package. |
+| `index.js:65` | `spawn('python3', pythonArgs, { stdio: 'inherit', shell: false })` | `shell: false` — argv passed as a discrete array, no shell interpretation, no shell-injection vector. User-supplied CLI args ARE forwarded into the Python process as argv entries; they are parsed by the Python CLI's `argparse`, not by a shell. Any vulnerability in argv handling belongs to the Python package, not this wrapper. Defense-in-depth: `validateArgs()` rejects argv entries containing null bytes before spawn. |
+
+The wrapper does not:
+- Concatenate user input into any shell command string.
+- Use `child_process.exec()` (which spawns a shell). Only `execSync` (with hardcoded literals) and `spawn` (with `shell: false`) are used.
+- Read environment variables that flow into a command string.
+- Execute any binary other than `python3`.
+
+False-positive reports for SafeSkill and other static scanners on these call
+sites should reference this section.
+
 ## Acknowledgments
 
 We thank the following researchers for responsible disclosure:

--- a/npm-wrapper/index.js
+++ b/npm-wrapper/index.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// child_process is required to bridge npm-distributed wrapper → python package.
+// Every call site below uses a hardcoded command string (no user-string concat
+// into a shell) and the spawn() invocation explicitly sets shell:false.
+// See SECURITY.md § "npm-wrapper subprocess invocations" for per-call rationale.
 const { spawn, execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
@@ -9,6 +13,8 @@ const fs = require('fs');
  * This script ensures the Python package is installed and then executes it.
  */
 
+// Probe: does python3 exist on PATH? Hardcoded command, stdio:'ignore' (no
+// output capture), no user input. Bounded subprocess — safe.
 function checkPython() {
     try {
         execSync('python3 --version', { stdio: 'ignore' });
@@ -18,6 +24,8 @@ function checkPython() {
     }
 }
 
+// Probe: is the python package importable? Hardcoded command, stdio:'ignore'.
+// No user input. Bounded subprocess — safe.
 function isInstalled() {
     try {
         execSync('python3 -m mcp_server_nucleus --help', { stdio: 'ignore' });
@@ -27,6 +35,10 @@ function isInstalled() {
     }
 }
 
+// Install the python package from PyPI. Hardcoded command + hardcoded package
+// name — no user input flows into the command string. stdio:'inherit' streams
+// pip's output to the user's terminal. By-design behavior of an npm-wrapper
+// over a python package; equivalent to `npm install` for native dependencies.
 function install() {
     console.error('[Nucleus] Installing Python dependencies (nucleus-mcp)...');
     try {
@@ -36,6 +48,18 @@ function install() {
         console.error('[Nucleus] ERROR: Failed to install nucleus-mcp via pip.');
         console.error(e.message);
         return false;
+    }
+}
+
+// Defense-in-depth: reject CLI args containing null bytes. shell:false on the
+// spawn() below already prevents shell injection, but a null byte in argv can
+// truncate strings inside execve() on some platforms. Cheap belt-and-suspenders.
+function validateArgs(args) {
+    for (const arg of args) {
+        if (typeof arg !== 'string' || arg.indexOf('\0') !== -1) {
+            console.error('[Nucleus] ERROR: invalid CLI argument (null byte or non-string).');
+            process.exit(2);
+        }
     }
 }
 
@@ -54,6 +78,7 @@ async function run() {
     // Determine which command was called
     const binName = path.basename(process.argv[1]);
     const args = process.argv.slice(2);
+    validateArgs(args);
 
     let pythonArgs = [];
     if (binName === 'nucleus-init') {
@@ -62,6 +87,10 @@ async function run() {
         pythonArgs = ['-m', 'mcp_server_nucleus', ...args];
     }
 
+    // User-supplied CLI args ARE forwarded into the python process, but as
+    // discrete argv entries — shell:false guarantees no shell interpretation.
+    // The python CLI itself parses argv via argparse; any vulnerability there
+    // belongs to the python package, not this wrapper. Bounded subprocess.
     const child = spawn('python3', pythonArgs, {
         stdio: 'inherit',
         shell: false


### PR DESCRIPTION
## Why

[SafeSkill PR #10](https://github.com/eidetic-works/nucleus-mcp/pull/10) flagged `npm-wrapper/index.js` 30/100 (BLOCKED) on five `child_process` call sites. Cowork directive `relay_20260426_051334_4d77c3eb` (founder-approved) routed option (b): fix the actual findings first, then re-scan + ship a Pass badge — do not merge the BLOCKED-badge PR as-is.

## Audit verdict — all five findings are static-pattern false-positives

| Line | Call | Bounded by |
|---|---|---|
| `index.js:14` | `execSync('python3 --version')` | Hardcoded literal, `stdio:'ignore'`, no user input |
| `index.js:23` | `execSync('python3 -m mcp_server_nucleus --help')` | Hardcoded literal, `stdio:'ignore'`, no user input |
| `index.js:33` | `execSync('python3 -m pip install nucleus-mcp')` | Hardcoded literal + hardcoded package name |
| `index.js:65` | `spawn('python3', pythonArgs, { shell: false })` | `shell: false` + array argv = no shell-injection vector. Argv parsed by python `argparse`, not a shell. |
| `index.js:3`  | `require('child_process')` | Module import — required for any npx wrapper that bridges to a non-Node binary |

The pattern is the textbook safe npm wrapper. SafeSkill is doing static call-site matching without flow analysis — it cannot tell `shell: true + concat` from `shell: false + array`.

## Changes

**`npm-wrapper/index.js`** — inline JSDoc next to each call explaining why it is bounded; add `validateArgs()` defense-in-depth that rejects null bytes in argv before `spawn` (shell:false already prevents shell injection; null bytes can truncate strings inside execve() on some platforms — cheap belt-and-suspenders).

**`SECURITY.md`** — new "npm-wrapper subprocess invocations" subsection under "Known Security Considerations" with per-call rationale table. Static-scanner false-positive reports can reference this.

## What this PR does not do

- Refactor any of the call sites — they are already safe.
- Touch any other file or behavior. `node -c` passes; smoke run on macOS unchanged.
- Open the SafeSkill false-positive issue (third-party repo — needs founder go).

## Next steps after merge

1. Open false-positive issue on https://github.com/OyadotAI/safeskill/issues citing SECURITY.md § "npm-wrapper subprocess invocations".
2. Request re-scan via SafeSkill (their PR body invites this: "False positive? ... please open an issue").
3. If re-scanned score clears BLOCKED → update PR #10 badge to new score, then merge it. If SafeSkill cannot improve content-score even with documented bounded pattern → close PR #10 (no badge worse than a misleading badge).

## Test plan

- [x] `node -c npm-wrapper/index.js` — JS syntax OK
- [x] `node npm-wrapper/index.js --version` — wrapper passes through to python; behavior unchanged
- [ ] Reviewer: confirm SECURITY.md § "npm-wrapper subprocess invocations" rationale matches each call site
- [ ] Reviewer: confirm `validateArgs()` rejects null-byte argv (defense-in-depth, no behavior change for legitimate args)

## Related

- cowork DIRECTIVE: `.brain/relay/claude_code_main/20260426_051334_relay_20260426_051334_4d77c3eb.json`
- 13-PR sweep ship-report (which surfaced this for founder-flag): `relay_20260426_044323_220157fb`